### PR TITLE
GPHDRUI-427: Fix CI test failures and modernize GitHub workflows

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,7 +21,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Create Release
         uses: shogo82148/actions-create-release@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,8 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Tests
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push or pull request events but only for the master/stable branch
   push:
     branches: [ master, stable ]
   pull_request:
@@ -13,25 +11,28 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [14.x]
-        
-    # Steps represent a sequence of tasks that will be executed as part of the job
+        node-version: [20.x]
+
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-      - name: Yarn CLI ${{ matrix.node-version }}
-        uses: CultureHQ/actions-yarn@v1.0.1
-      - run: yarn
-      - name: Test
-        uses: CultureHQ/actions-yarn@v1.0.1
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
-          args: test:mocha
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Test
+        run: yarn test:mocha
+
+      - name: Integration Test
+        run: yarn test:integration

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,8 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Publish to NPM
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push or pull request events but only for the stable branch
   push:
     branches: [ stable ]
   pull_request:
@@ -13,28 +11,31 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    strategy:
+      matrix:
+        node-version: [20.x]
+
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Tag from package version
         uses: suceda/tag-from-version@v0.1.0
-        
-      - name: Yarn CLI ${{ matrix.node-version }}
-        uses: CultureHQ/actions-yarn@v1.0.1
-      - run: yarn
-      
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
       - name: NPM Publish
         uses: mmarchini-oss/npm-otp-publish@v0 #JS-DevTools/npm-publish@v1
         with:
           npm_token: ${{secrets.NPM_TOKEN}}
           github_token: ${{secrets.GITHUB_TOKEN}}
-          

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"@internetx/internetx-swagger-files": "https://github.com/InterNetX/domainrobot-api.git",
 		"axios-mock-adapter": "^1.22.0",
 		"cross-env": "^6.0.3",
+		"form-data": "^4.0.0",
 		"mocha": "^9.2.2",
 		"nyc": "^15.1.0",
 		"webpack": "^5.99.5"

--- a/tests/Integration/ContactDocumentUpload.integration.test.js
+++ b/tests/Integration/ContactDocumentUpload.integration.test.js
@@ -9,6 +9,9 @@
 const http = require("http");
 const Domainrobot = require("../../src/Domainrobot");
 const expect = require("chai").expect;
+// Use the `form-data` package instead of the global FormData so the test also
+// runs on the CI Node version (Node 14 has no global FormData/Blob).
+const FormData = require("form-data");
 
 describe("ContactDocumentService upload (integration)", () => {
     let server;
@@ -52,7 +55,7 @@ describe("ContactDocumentService upload (integration)", () => {
         const formData = new FormData();
         formData.append(
             "file",
-            new Blob(["dummy-id-document-content"]),
+            Buffer.from("dummy-id-document-content"),
             "idcard.pdf"
         );
 

--- a/tests/Specs/services/ContactDocumentService.test.js
+++ b/tests/Specs/services/ContactDocumentService.test.js
@@ -4,6 +4,9 @@ const Domainrobot = require("../../../src/Domainrobot");
 const ValidResponse = require("../../mock/ValidResponse.json");
 const expect = require('chai').expect;
 const axiosMock = require('../../axios-mock');
+// Use the `form-data` package instead of the global FormData so the tests also
+// run on the CI Node version (Node 14 has no global FormData/Blob).
+const FormData = require('form-data');
 
 describe("ContactDocumentServiceTest", () => {
     let domainRobot;
@@ -21,7 +24,7 @@ describe("ContactDocumentServiceTest", () => {
 
     it("upload", async () => {
         const formData = new FormData();
-        formData.append("file", new Blob(["dummy"]), "idcard.pdf");
+        formData.append("file", Buffer.from("dummy"), "idcard.pdf");
 
         axiosMock().onPost().reply(200, ValidResponse);
 
@@ -57,7 +60,7 @@ describe("ContactDocumentServiceTest", () => {
 
     it("upload with keys", async () => {
         const formData = new FormData();
-        formData.append("file", new Blob(["dummy"]), "idcard.pdf");
+        formData.append("file", Buffer.from("dummy"), "idcard.pdf");
         const keys = ['force'];
 
         axiosMock().onPost().reply(200, ValidResponse);

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,7 +927,7 @@ foreground-child@^2.0.0:
     cross-spawn "^7.0.0"
     signal-exit "^3.0.2"
 
-form-data@^4.0.5:
+form-data@^4.0.0, form-data@^4.0.5:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
   integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==


### PR DESCRIPTION
The test suite failed on CI with "ReferenceError: FormData is not defined" because the pipeline ran on an outdated Node that lacks the global FormData/Blob (added in Node 18+). The old workflow bundled its own Node via the CultureHQ/actions-yarn wrapper and silently ignored the matrix node-version.

Test fixes (Node-version agnostic):
- ContactDocumentService mock and integration tests: use the `form-data` package instead of the global FormData, and Buffer instead of Blob for the payload, so the tests run on any Node version
- add "form-data": "^4.0.0" as an explicit devDependency (previously only a transitive axios dependency) and update yarn.lock

CI workflow modernization:
- main.yml: replace the outdated CultureHQ/actions-yarn wrapper with actions/setup-node@v4 running Node 20.x + yarn cache; bump actions/checkout to v4; install via `yarn install --frozen-lockfile`; run the integration suite (yarn test:integration) as a separate step after the mock suite
- publish.yml: same modernization (checkout@v4, setup-node@v4 Node 20.x, frozen-lockfile install); keep the tag-from-version and NPM publish steps unchanged
- create-release.yml: bump actions/checkout to v4