### PR TITLE
GPHDRUI-427: Fix GET requests sending a stray "null" body under axios…

### DIFF
--- a/src/services/DomainRobotService.js
+++ b/src/services/DomainRobotService.js
@@ -88,13 +88,19 @@ class DomainRobotService {
         return this;
     }
 
-    async sendRequest(method, url, data = null) {
+    async sendRequest(method, url, data = undefined) {
         try {
             let requestOptions = Object.assign(
                 {
                     method,
                     url: encodeURI(url),
-                    data
+                    // Only attach `data` when the caller actually provided a body.
+                    // Passing `data: null`/`data: undefined` explicitly still makes axios
+                    // serialize it into a literal "null" body (given the forced
+                    // Content-Type: application/json default below), which breaks
+                    // GET requests against APIs that reject a body on GET or that
+                    // strictly parse the JSON body as an object/array.
+                    ...(data !== undefined ? { data } : {})
                 },
                 this.axiosconfig
             );
@@ -148,8 +154,8 @@ class DomainRobotService {
         }
     }
 
-    async sendGetRequest(url) {
-        return this.sendRequest("GET", url);
+    async sendGetRequest(url, data = undefined) {
+        return this.sendRequest("GET", url, data);
     }
 
     async sendPostRequest(url, data) {


### PR DESCRIPTION
… 1.x

sendRequest() defaulted `data` to `null` and always attached it to the axios request config. With axios 1.18.1 (bumped from 0.x in a prior commit) and the forced Content-Type: application/json default header, this caused axios to serialize the null default into a literal "null" body on every GET request, which some APIs (e.g. account-json-server) reject as an invalid top-level JSON value.

`data` is now only attached when explicitly provided, and sendGetRequest() accepts an optional body for callers that need one.