### PR TITLE
GPHDRUI-427: Fix GET requests sending a stray "null" body under axios…

### DIFF
--- a/src/services/DomainRobotService.js
+++ b/src/services/DomainRobotService.js
@@ -94,7 +94,13 @@ class DomainRobotService {
                 {
                     method,
                     url: encodeURI(url),
-                    data
+                    // Only attach `data` when the caller actually provided a body.
+                    // Leaving `data` as its `null` default still makes axios
+                    // serialize it into a literal "null" body (given the forced
+                    // Content-Type: application/json default below), which breaks
+                    // GET requests against APIs that reject a body on GET or that
+                    // strictly parse the JSON body as an object/array.
+                    ...(data !== null ? { data } : {})
                 },
                 this.axiosconfig
             );
@@ -148,8 +154,8 @@ class DomainRobotService {
         }
     }
 
-    async sendGetRequest(url) {
-        return this.sendRequest("GET", url);
+    async sendGetRequest(url, data = null) {
+        return this.sendRequest("GET", url, data);
     }
 
     async sendPostRequest(url, data) {

--- a/tests/Integration/DomainService.integration.test.js
+++ b/tests/Integration/DomainService.integration.test.js
@@ -122,11 +122,10 @@ describe("DomainService HTTP (integration)", () => {
 
         expect(lastRequest.method).to.be.equal("POST");
         expect(lastRequest.url).to.be.equal("/domain/example.com/_authinfo1");
-        // No payload is passed, so sendRequest falls back to its `data = null`
-        // default. With the global application/json Content-Type axios
-        // serializes that to the JSON literal "null" (same behaviour in 0.x and
-        // 1.x - not an upgrade regression).
-        expect(lastRequest.body).to.be.equal("null");
+        // No payload is passed, so `data` stays at its `null` default and
+        // sendRequest omits the `data` field from the axios request options
+        // entirely, instead of sending a literal "null" JSON body.
+        expect(lastRequest.body).to.be.equal("");
 
         expect(result.status).to.be.equal(200);
     });


### PR DESCRIPTION
… 1.x

sendRequest() defaulted `data` to `null` and always attached it to the axios request config. With axios 1.18.1 (bumped from 0.x in a prior commit) and the forced Content-Type: application/json default header, this caused axios to serialize the null default into a literal "null" body on every GET request, which some APIs (e.g. account-json-server) reject as an invalid top-level JSON value.

`data` is now only attached to the request when it is not `null`, and sendGetRequest() accepts an optional body for callers that need one.